### PR TITLE
Fix/encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+md_output/
+.venv

--- a/wiki-to-md-images.py
+++ b/wiki-to-md-images.py
@@ -46,7 +46,7 @@ def generate_markdown(topic):
 
     filename = os.path.join(output_directory, f'{topic.replace(" ", "_")}.md')
 
-    with open(filename, "w") as md_file:
+    with open(filename, "w", encoding="utf-8") as md_file:
         md_file.write(markdown_text)
 
     print(f"Markdown file created: {filename}")

--- a/wiki-to-md.py
+++ b/wiki-to-md.py
@@ -32,7 +32,7 @@ def generate_markdown(topic):
 
     filename = os.path.join(directory, f"{topic.replace(' ', '_')}.md")
 
-    with open(filename, "w") as md_file:
+    with open(filename, "w", encoding="utf-8") as md_file:
         md_file.write(markdown_text)
 
     print(f"Markdown file created: {filename}")


### PR DESCRIPTION
### Summary
This pull request fixes an issue where a `UnicodeEncodeError` was raised when generating markdown files containing certain Unicode characters.

### Description
When running the script `wiki-to-md-images.py` to generate markdown files, a `UnicodeEncodeError` was encountered due to the default encoding not supporting certain Unicode characters. This error occurred when writing to the file:

UnicodeEncodeError: 'charmap' codec can't encode character '\u2190' in position 6391: character maps to <undefined>

To resolve this issue, I specified `utf-8` encoding when opening the file for writing, ensuring that all Unicode characters are properly supported.

### Changes
- Updated `wiki-to-md-images.py` and `wiki-to-md.py` to open the markdown file with `utf-8` encoding.

### Testing
- Ran the script with various topics containing Unicode characters and confirmed that the markdown files were generated successfully without any encoding errors.

### Additional Change
- A .gitignore file was also added to avoid pushing the `md_output` directory accidentally.