### PR TITLE
Added an option to set the 2-letter language code for the Wikipedia page

### DIFF
--- a/wiki-to-md-images.py
+++ b/wiki-to-md-images.py
@@ -68,8 +68,17 @@ parser.add_argument(
     default='yes',
     help="Specify whether to download images (yes or no).",
 )
+parser.add_argument(
+    "--lang",
+    type=str,
+    default="en",
+    help="The 2-letter language code for the Wikipedia page (default: 'en')."
+)
 
 args = parser.parse_args()
+
+# Set the language for Wikipedia if provided
+wikipedia.set_lang(args.lang)
 
 topic = f"{args.topic}"
 download_images = args.dl_image == 'yes'

--- a/wiki-to-md.py
+++ b/wiki-to-md.py
@@ -47,9 +47,19 @@ parser.add_argument(
     type=str,
     help="The topic to generate a markdown file for.",
 )
+parser.add_argument(
+    "--lang",
+    type=str,
+    default="en",
+    help="The 2-letter language code for the Wikipedia page (default: 'en')."
+)
 
 args = parser.parse_args()
+
+# Set the language for Wikipedia if provided
+wikipedia.set_lang(args.lang)
 
 topic = f"{args.topic}"
 
 generate_markdown(topic)
+


### PR DESCRIPTION
Hi everyone.
I added the ability to download wiki pages in languages other than English by setting the optional "--lang <2-digit-language-code>".
Cheers,
Mothe