### PR TITLE
Added "auto_suggest=False" to wikipedia page call

### DIFF
--- a/wiki-to-md-images.py
+++ b/wiki-to-md-images.py
@@ -8,7 +8,7 @@ import urllib.parse
 
 def generate_markdown(topic, download_images):
     try:
-        page = wikipedia.page(topic)
+        page = wikipedia.page(topic, auto_suggest=False)
     except wikipedia.exceptions.DisambiguationError as e:
         print(e.options)
         return None

--- a/wiki-to-md.py
+++ b/wiki-to-md.py
@@ -6,7 +6,7 @@ import re
 
 def generate_markdown(topic):
     try:
-        page = wikipedia.page(topic)
+        page = wikipedia.page(topic, auto_suggest=False)
     except wikipedia.exceptions.DisambiguationError as e:
         print(e.options)
         return None


### PR DESCRIPTION
For some reason, the wikipedia API on python won't grab some pages even if the topic string is an exact match. Example: `VT100`. To fix this, I just added the `auto_suggest=False` parameter to the wiki page call.

https://stackoverflow.com/questions/66630711/the-wikipedia-api-seems-to-almost-always-get-the-word-in-question-wrong